### PR TITLE
fix rewarder for float rounding issue

### DIFF
--- a/src/Rewarder.sol
+++ b/src/Rewarder.sol
@@ -657,12 +657,18 @@ contract Rewarder is
 
         if (amountToRelease > 0) {
             EnumerableMapUpgradeable.AddressToUintMap storage map = _totalRewardsPerEpoch[market][epoch];
-            map.set(address(token), map.get(address(token)) - amountToRelease);
 
-            uint256 totalReleased = released + amountToRelease;
+            uint256 totalAmount = map.get(address(token));
+            amountToRelease = amountToRelease > totalAmount ? totalAmount : amountToRelease;
 
-            _released[id] = totalReleased;
-            unreleased = amount - totalReleased;
+            map.set(address(token), totalAmount - amountToRelease);
+
+            {
+                uint256 totalReleased = released + amountToRelease;
+
+                _released[id] = totalReleased;
+                unreleased = totalAmount == amountToRelease ? 0 : amount - totalReleased;
+            }
 
             _totalUnreleasedRewards[token] -= amountToRelease;
             _transferNativeOrERC20(token, recipient, amountToRelease);

--- a/test/Rewarder.UpdateArbitrum.sol
+++ b/test/Rewarder.UpdateArbitrum.sol
@@ -15,7 +15,7 @@ contract UpdateArbitrum is Test {
     ProxyAdmin public proxyAdmin = ProxyAdmin(0xa0BA87c58C7D09f859843256A9b87253F9a26C98);
 
     function setUp() public {
-        vm.createSelectFork(stdChains["arbitrum_one"].rpcUrl);
+        vm.createSelectFork("https://rpc.ankr.com/arbitrum", 71_910_974);
     }
 
     function testRewarder() public {

--- a/test/Rewarder.t.sol
+++ b/test/Rewarder.t.sol
@@ -10,6 +10,15 @@ import "../src/Rewarder.sol";
 import "./mocks/MockERC20.sol";
 
 contract RewarderTest is Test {
+    event RewardClaimed(
+        address indexed user,
+        address indexed market,
+        IERC20Upgradeable indexed token,
+        uint256 epoch,
+        uint256 released,
+        uint256 unreleased
+    );
+
     Merkle public merkle;
 
     Rewarder public implementation;
@@ -1423,11 +1432,13 @@ contract RewarderTest is Test {
 
         vm.warp(start + duration);
 
-        vm.expectRevert();
+        vm.expectEmit(true, true, true, true);
+        emit RewardClaimed(ALICE, MARKET_A, IERC20Upgradeable(address(TOKEN_A)), epoch, 99, 0);
         vm.prank(ALICE);
         rewarder.claim(MARKET_A, epoch, IERC20Upgradeable(address(TOKEN_A)), 100, proof0);
 
-        vm.expectRevert();
+        vm.expectEmit(true, true, true, true);
+        emit RewardClaimed(BOB, MARKET_A, IERC20Upgradeable(address(TOKEN_B)), epoch, 199, 0);
         vm.prank(BOB);
         rewarder.claim(MARKET_A, epoch, IERC20Upgradeable(address(TOKEN_B)), 200, proof1);
     }


### PR DESCRIPTION
Fix rounding issue by taking the `rewardForUser = min(totalReward, rewardForUser)`.
For users that have their rewards rounded down, the event will emit an `unreleased` of 0 if the remaining can't be rewarded.